### PR TITLE
docs(env): clarify acme DEFAULT_EMAIL vs per-container LETSENCRYPT_EMAIL

### DIFF
--- a/mail/.env.template
+++ b/mail/.env.template
@@ -2,6 +2,7 @@
 # --------------------- Domain Settings --------------------------------------------------------------------------------
 # ----------------------------------------------------------------------------------------------------------------------
 
+# nginx-proxy / acme-companion: leave LETSENCRYPT_EMAIL empty when userver-web sets DEFAULT_EMAIL once.
 VIRTUAL_HOST=
 LETSENCRYPT_HOST=
 LETSENCRYPT_EMAIL=

--- a/postfixadmin/.env.template
+++ b/postfixadmin/.env.template
@@ -1,3 +1,4 @@
+# nginx-proxy / acme-companion: leave LETSENCRYPT_EMAIL empty when userver-web sets DEFAULT_EMAIL once.
 VIRTUAL_HOST=
 LETSENCRYPT_HOST=
 LETSENCRYPT_EMAIL=

--- a/webmail/.env.template
+++ b/webmail/.env.template
@@ -1,3 +1,4 @@
+# nginx-proxy / acme-companion: leave LETSENCRYPT_EMAIL empty when userver-web sets DEFAULT_EMAIL once.
 VIRTUAL_HOST=
 LETSENCRYPT_HOST=
 LETSENCRYPT_EMAIL=


### PR DESCRIPTION
Document that repeating the same email on many containers breaks ACME when using userver-web nginx-proxy / acme-companion (addresses get concatenated).

Made-with: Cursor

## Scope
<!-- Describe all the changes briefly with bullet points. -->

## Checklist
- [ ] Shell scripts follow existing style; ShellCheck is clean where applicable
- [ ] Integration / CI path updated if `ci/compose.yaml` or `scripts/ci-prepare.sh` changed
- [ ] Workflows and README badges remain accurate for this repository

Thank you!
