### PR TITLE
fix: mail domain FQDN env

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,13 +35,9 @@ Part of the [uServer](https://github.com/users/ferdn4ndo/projects/1) project.
    - `backup/.env.template` → `backup/.env` (if using backups)
    - `postfixadmin/.env.template` → `postfixadmin/.env` (if using PostfixAdmin)
 
-2. **Compose hostname:** Create a `.env` file **next to** `docker-compose.yml` with:
+2. **Compose hostname + DMS TLS:** Create a `.env` file **next to** `docker-compose.yml` with `MAIL_FQDN` set to your mail **FQDN** (same as MX / the name under `../userver-web/certs` for Let’s Encrypt, e.g. `mail.sd40.com.br`). If `MAIL_FQDN` is missing, Compose falls back to `mail.example.com` and docker-mailserver will look for certs under **that** name — which breaks `SSL_TYPE=letsencrypt` when your real cert folder uses your real domain.
 
-   ```bash
-   MAIL_FQDN=mail.example.com
-   ```
-
-   Use the same FQDN as `OVERRIDE_HOSTNAME` / your MX record. Compose substitutes this into the mail container `hostname` (recommended by docker-mailserver).
+   In `mail/.env`, set **`OVERRIDE_HOSTNAME`** to the **same FQDN** as `LETSENCRYPT_HOST` / `MAIL_FQDN`. DMS does not read `LETSENCRYPT_HOST`; it needs `OVERRIDE_HOSTNAME` (or a correct container hostname) to resolve `/etc/letsencrypt/live/<FQDN>/`.
 
 3. Ensure the external Docker network `nginx-proxy` exists (or change the `networks` section in `docker-compose.yml`).
 

--- a/mail/.env.template
+++ b/mail/.env.template
@@ -7,6 +7,12 @@ VIRTUAL_HOST=
 LETSENCRYPT_HOST=
 LETSENCRYPT_EMAIL=
 
+# DMS does NOT read VIRTUAL_HOST / LETSENCRYPT_HOST. For SSL_TYPE=letsencrypt it looks under
+# /etc/letsencrypt/live/<FQDN>/ (see docker-compose volume from userver-web certs).
+# Set OVERRIDE_HOSTNAME to that same FQDN (typically identical to LETSENCRYPT_HOST), and set
+# MAIL_FQDN in the .env next to docker-compose.yml to the same value (compose `hostname:`).
+OVERRIDE_HOSTNAME=
+
 HOSTNAME=<subdomain>
 DOMAINNAME=<domain>
 
@@ -20,10 +26,6 @@ DOMAINNAME=<domain>
 # -----------------------------------------------
 # --- General Section ---------------------------
 # -----------------------------------------------
-
-# empty => uses the `hostname` command to get the mail server's canonical hostname
-# => Specify a fully-qualified domainname to serve mail for.  This is used for many of the config features so if you can't set your hostname (e.g. you're in a container platform that doesn't let you) specify it in this environment variable.
-OVERRIDE_HOSTNAME=
 
 # Set the log level for DMS.
 # This is mostly relevant for container startup scripts and change detection event feedback.
@@ -336,7 +338,7 @@ DOVECOT_INET_PROTOCOLS=all
 # 1 => SpamAssassin is enabled
 ENABLE_SPAMASSASSIN=0
 
-# deliver spam messages in the inbox (eventually tagged using SA_SPAM_SUBJECT)
+# deliver spam messages in the inbox (eventually tagged using SPAM_SUBJECT)
 SPAMASSASSIN_SPAM_TO_INBOX=1
 
 # KAM is a 3rd party SpamAssassin ruleset, provided by the McGrail Foundation.
@@ -359,8 +361,8 @@ SA_TAG2=6.31
 # triggers spam evasive actions
 SA_KILL=6.31
 
-# add tag to subject if spam detected
-SA_SPAM_SUBJECT=***SPAM*****
+# add tag to subject if spam detected (v15+: use SPAM_SUBJECT; SA_SPAM_SUBJECT is deprecated)
+SPAM_SUBJECT=***SPAM*****
 
 # -----------------------------------------------
 # --- Fetchmail Section -------------------------


### PR DESCRIPTION
## Scope
<!-- Describe all the changes briefly with bullet points. -->
- Fixing hostname env;
- Fixing legacy spam subject env;

## Checklist
- [x] Shell scripts follow existing style; ShellCheck is clean where applicable
- [x] Integration / CI path updated if `ci/compose.yaml` or `scripts/ci-prepare.sh` changed
- [x] Workflows and README badges remain accurate for this repository

Thank you!
